### PR TITLE
Json format 0.2

### DIFF
--- a/assets/browse.js
+++ b/assets/browse.js
@@ -22,12 +22,12 @@ function capitalise(str, divider = ' ') {
 // ONE-TIME FUNCTIONS
 // ==================
 
-function renderCards(cardData, orderedDataUrls) {
+function renderCards(cardData) {
 	// Render theme list
-	for(let [themeId, theme] of Object.entries(cardData)) {
+	for(let theme of cardData) {
 		let cardParent = document.createElement('a');
 		cardParent.className = 'browser__card';
-		cardParent.href = `./theme?q=${themeId}&data=${orderedDataUrls.join('&data=')}`;
+		cardParent.href = `./theme?t=${theme['url']}&c=${collectionUrls.join('&c=')}`;
 
 		let card = document.createElement('div');
 		card.className = 'card';
@@ -86,21 +86,26 @@ function renderCards(cardData, orderedDataUrls) {
 
 // Variables
 
+// Redirect from old URL format to new one
 let theme = query.get('q') || query.get('theme');
 if(theme) {
 	window.location = `./theme?q=${theme}&data=${dataUrls.join('&data=')}`;
 	throw new Error();
 }
 
-// Get data for all themes and call other functions
+// Get data for all collections and call other functions
 
-const dataFiles = [];
+const collectionFiles = [];
 
-for(let i = 0; i < dataUrls.length; i++) {
-	dataFiles.push(fetchFile(dataUrls[i], false));
+if(collectionUrls.length === 0) {
+	collectionUrls.push(['./assets/collection.json']);
 }
 
-Promise.allSettled(dataFiles)
+for(let i = 0; i < collectionUrls.length; i++) {
+	collectionFiles.push(fetchFile(collectionUrls[i], false));
+}
+
+Promise.allSettled(collectionFiles)
 	.then((files) => {
 		let failures = 0;
 
@@ -115,15 +120,7 @@ Promise.allSettled(dataFiles)
 				continue;
 			}
 
-			// Put the relevant dataUrl at the beginning so the theme will read the correct one
-			let orderedDataUrls = dataUrls;
-			if(i > 0) {
-				let temp = orderedDataUrls[i];
-				orderedDataUrls.splice(i, 1);
-				orderedDataUrls.unshift(temp);
-			}
-
-			renderCards(tempData, orderedDataUrls);
+			renderCards(tempData['themes']);
 		}
 
 		if(failures >= files.length) {

--- a/assets/browse.js
+++ b/assets/browse.js
@@ -113,9 +113,10 @@ Promise.allSettled(collectionFiles)
 				continue;
 			}
 
-			tempData = processJson(tempData, collectionUrls[i], 'collection');
-
-			renderCards(tempData['themes']);
+			processJson(tempData, collectionUrls[i], 'collection')
+			.then((processedJson) => {
+				renderCards(processedJson['themes']);
+			})
 		}
 
 		if(failures >= files.length) {

--- a/assets/browse.js
+++ b/assets/browse.js
@@ -86,13 +86,6 @@ function renderCards(cardData) {
 
 // Variables
 
-// Redirect from old URL format to new one
-let theme = query.get('q') || query.get('theme');
-if(theme) {
-	window.location = `./theme?q=${theme}&data=${dataUrls.join('&data=')}`;
-	throw new Error();
-}
-
 // Get data for all collections and call other functions
 
 const collectionFiles = [];
@@ -119,6 +112,8 @@ Promise.allSettled(collectionFiles)
 				failures++;
 				continue;
 			}
+
+			tempData = processJson(tempData, collectionUrls[i], 'collection');
 
 			renderCards(tempData['themes']);
 		}

--- a/assets/collection.json
+++ b/assets/collection.json
@@ -1,0 +1,11 @@
+{
+	"json_version": 0.2,
+	"themes": [
+		{
+			"name": "Example",
+			"author": "Your Name Here",
+			"type": "modern",
+			"url": "./assets/theme.json"
+		}
+	]
+}

--- a/assets/common.js
+++ b/assets/common.js
@@ -219,8 +219,8 @@ async function processJson(json, url, toReturn) {
 // json v0.0 > v0.1
 
 // Redirect from browse page to theme page if a theme is specified
+let themeQuery = query.get('q') || query.get('theme')
 if(path !== '/theme' && themeQuery && dataUrls.length > 0) {
-	let themeQuery = query.get('q') || query.get('theme')
 	window.location = `./theme?q=${themeQuery}&c=${dataUrls.join('&c=')}`;
 	throw new Error();
 }

--- a/assets/common.js
+++ b/assets/common.js
@@ -138,10 +138,16 @@ function fetchFile(path, cacheResult = true) {
 
 const
 	query = (new URL(document.location)).searchParams,
-	dataUrls = query.getAll('data'),
+	collectionUrls = query.getAll('c'),
+	themeUrls = query.getAll('t'),
 	loader = new loadingScreen(),
 	messenger = new messageHandler();
 
-if(dataUrls.length === 0) {
-	dataUrls.push(['./assets/data.json']);
+// Detect and Manage legacy JSON versions
+
+// json v0.1 > v0.2
+
+const dataUrls = query.getAll('data');
+if(dataUrls.length > 0) {
+	messenger.warn('The loaded JSON has been processed as JSON v0.1 due to out-of-date formatting. If you are the JSON author, please see the GitHub page for assistance updating.');
 }

--- a/assets/common.js
+++ b/assets/common.js
@@ -151,12 +151,11 @@ const
 // LEGACY JSON MANAGEMENT
 // Detect and Manage legacy JSON versions and URL parameters.
 
-let path = window.location.pathname;
-	themeQuery = query.get('t') || query.get('q') || query.get('theme'),
+let path = window.location.pathname,
 	dataUrls = query.getAll('data');
 
 // Check for legacy JSON and process as needed
-function processJson(json, url, toReturn) {
+async function processJson(json, url, toReturn) {
 	var ver = 0;
 	if(!('json_version' in json)) {
 		ver = 0.1;
@@ -166,18 +165,53 @@ function processJson(json, url, toReturn) {
 
 	// Process as normal if version is good
 	if(ver === jsonVersion) {
-		return json;
+		// Process as collection or fetch correct theme from collection
+		if(toReturn === 'collection' && 'themes' in json
+		|| toReturn === 'theme' && 'data' in json) {
+			// Convert legacy dictionary to array
+			if('themes' in json && !Array.isArray(json['themes'])) {
+				let arrayThemes = [];
+				for(let t of Object.values(json['themes'])) {
+					arrayThemes.push(t);
+				}
+				json['themes'] = arrayThemes;
+			}
+			return json;
+		}
+		else if('themes' in json && toReturn in json['themes']) {
+			let themeUrl = json['themes'][toReturn]['url'];
+			if(themeUrl) {
+				return fetchFile(themeUrl)
+				.then((result) => {
+					let themeJson = '';
+					try {
+						themeJson = JSON.parse(result);
+					} catch {
+						themeJson = false;
+					}
+					return themeJson;
+				})
+				.catch(() => {
+					return false;
+				});
+			}
+		}
+		else {
+			return false;
+		}
 	}
 
 	// Else, continue to process.
-	if(ver > jsonVersion) {
+	else if(ver > jsonVersion) {
 		messenger.warn('Detected JSON version ahead of current release. Processing as normal.');
 		return json;
 	}
 
-	messenger.warn('The loaded JSON has been processed as legacy JSON. This can cause slowdowns or errors. If you are the JSON author, please see the GitHub page for assistance updating.');
-	if(ver === 0.1) {
-		return updateToBeta2(json, url, toReturn);
+	else {
+		messenger.warn('The loaded JSON has been processed as legacy JSON. This can cause slowdowns or errors. If you are the JSON author, please see the GitHub page for assistance updating.');
+		if(ver === 0.1) {
+			return updateToBeta2(json, url, toReturn);
+		}
 	}
 }
 
@@ -186,7 +220,8 @@ function processJson(json, url, toReturn) {
 
 // Redirect from browse page to theme page if a theme is specified
 if(path !== '/theme' && themeQuery && dataUrls.length > 0) {
-	window.location = `./theme?q=${themeQuery}&data=${dataUrls.join('&data=')}`;
+	let themeQuery = query.get('q') || query.get('theme')
+	window.location = `./theme?q=${themeQuery}&c=${dataUrls.join('&c=')}`;
 	throw new Error();
 }
 
@@ -202,8 +237,6 @@ if(dataUrls.length > 0) {
 		}
 		modifiedQuery.append(key, val);
 	}
-	// Add first data as theme
-	modifiedQuery.append('t', query.get('data'));
 	// Redirect
 	window.location = `${window.location.href.split('?')[0]}?${modifiedQuery.toString()}`;
 	throw new Error();

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1131,24 +1131,9 @@ function importPreviousOpts(opts = undefined) {
 
 	localStorage.setItem('tcUserOptsImported', JSON.stringify(previousOpts));
 	
-	// If theme is wrong, offer to redirect.
-	if(userOpts['theme'] !== previousOpts['theme']) {
-		confirm('You are on the wrong theme page for the imported settings. Redirect to the correct theme page?')
-		.then((choice) => {
-			if(choice) {
-				localStorage.setItem('tcImport', true);
-				window.location = `./theme?q=${previousOpts['theme']}&data=${previousOpts['data']}`;
-			} else {
-				localStorage.removeItem('tcImport');
-				messenger.send('Action aborted.');
-			}
-		});
-
-		return false;
-	}
-	// If theme is correct but data isn't, offer to redirect or try importing anyway.
-	else if(userOpts['data'] !== previousOpts['data']) {
-		let msg = 'Source data from imported settings mismatches the source data on the current page. Redirect and use the imported source data?',
+	// If theme or data is wrong, offer to redirect or to try importing anyway.
+	if(userOpts['theme'] !== previousOpts['theme'] || userOpts['data'] !== previousOpts['data']) {
+		let msg = 'There is a mismatch between your imported settings and the current page. Redirect to the page indicated in your import?',
 			choices = {
 				'Yes': {'value': 'redirect', 'type': 'suggested'},
 				'No, apply settings here.': {'value': 'ignore'},
@@ -1159,7 +1144,7 @@ function importPreviousOpts(opts = undefined) {
 		.then((choice) => {
 			if(choice === 'redirect') {
 				localStorage.setItem('tcImport', true);
-				window.location = `./theme?q=${previousOpts['theme']}&data=${previousOpts['data']}`;
+				window.location = `./theme?q=${previousOpts['theme']}&t=${previousOpts['data']}`;
 			} else if(choice === 'ignore') {
 				applyPreviousOpts(previousOpts);
 				return true;
@@ -1351,6 +1336,7 @@ fetchData.then((json) => {
 		throw new Error('invalid theme');
 	} else {
 		theme = json['data'];
+		userOpts['theme'] = selectedTheme || theme['name'];
 	}
 
 	document.getElementsByTagName('title')[0].textContent = `Theme Customiser - ${theme['name']}`;

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1337,7 +1337,7 @@ fetchData.then((json) => {
 	}
 
 	// Check for legacy json
-	if(!(themeUrls.length > 0 && collectionUrls.includes(themeUrls[0]))) {
+	if(themeUrls.length > 0 && collectionUrls.includes(themeUrls[0])) {
 		selectedTheme = 'theme';
 	}
 	processJson(json, themeUrls[0], selectedTheme ? selectedTheme : 'theme')

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1341,8 +1341,12 @@ fetchData.then((json) => {
 		throw new Error('json.parse');
 	}
 
+	// Check for legacy json
+	let selectedTheme = query.get('q') || query.get('theme');
+	json = processJson(json, themeUrls[0], selectedTheme);
+
 	// Get theme info from URL & take action if problematic
-	if(theme === null) {
+	if(json === false) {
 		loader.failed(['Encountered a problem while parsing theme information.', 'invalid theme']);
 		throw new Error('invalid theme');
 	} else {

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1337,7 +1337,7 @@ fetchData.then((json) => {
 	}
 
 	// Check for legacy json
-	if(themeUrls.length > 0 && collectionUrls.includes(themeUrls[0])) {
+	if(themeUrls.length > 0 && collectionUrls.includes(themeUrls[0]) && !selectedTheme) {
 		selectedTheme = 'theme';
 	}
 	processJson(json, themeUrls[0], selectedTheme ? selectedTheme : 'theme')

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1332,8 +1332,11 @@ fetchData.then((json) => {
 
 	// Get theme info from URL & take action if problematic
 	if(json === false) {
-		loader.failed(['Encountered a problem while parsing theme information.', 'invalid theme']);
-		throw new Error('invalid theme');
+		loader.failed(['Encountered a problem while parsing theme information.', 'invalid.name']);
+		throw new Error('invalid theme name');
+	} else if(!('data' in json)) {
+		loader.failed(['Encountered a problem while parsing theme information.', 'invalid.json']);
+		throw new Error('invalid json format');
 	} else {
 		theme = json['data'];
 		userOpts['theme'] = selectedTheme || theme['name'];

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -846,11 +846,10 @@ function renderHtml() {
 	}
 
 	// Back link
-	// Todo: Check more accurately if there is more than one theme. Currently it just checks if there is more than one theme OR more than one json
-	if(Object.keys(data).length > 1 || dataUrls.length > 1) {
+	if(collectionUrls.length > 0) {
 		let back = document.getElementById('js-back');
 		back.classList.remove('o-hidden');
-		back.href = `./?data=${dataUrls.join('&data=')}`;
+		back.href = `./?c=${collectionUrls.join('&c=')}`;
 	}
 
 	// Help links
@@ -1313,31 +1312,29 @@ function postToIframe(msg) {
 
 // Variables
 
-var selectedTheme = query.get('q'),
-	theme = '',
-	data = null,
+var theme = '',
+	json = null,
 	baseCss = '';
 
 var userOpts = {
-	'theme': selectedTheme,
-	'data': dataUrls[0],
+	'data': themeUrls[0],
 	'options': {},
 	'mods': {}
 };
 
-if(selectedTheme === null) {
+if(themeUrls.length === 0) {
 	loader.failed(['No theme was specified in the URL. Did you follow a broken link?', 'select']);
 	throw new Error('select');
 }
 
 // Get data for all themes and call other functions
 
-let fetchData = fetchFile(dataUrls[0], false);
+let fetchData = fetchFile(themeUrls[0], false);
 
 fetchData.then((json) => {
 	// Attempt to parse provided data.
 	try {
-		data = JSON.parse(json);
+		json = JSON.parse(json);
 	} catch(e) {
 		console.log(`[fetchData] Error during JSON.parse: ${e}`);
 		loader.failed(['Encountered a problem while parsing theme information.', 'json.parse']);
@@ -1345,13 +1342,11 @@ fetchData.then((json) => {
 	}
 
 	// Get theme info from URL & take action if problematic
-	if(theme === null || !(selectedTheme.toLowerCase() in data)) {
-		// redirect in future using: window.location = '?';
-		// for now, simply fails
+	if(theme === null) {
 		loader.failed(['Encountered a problem while parsing theme information.', 'invalid theme']);
 		throw new Error('invalid theme');
 	} else {
-		theme = data[selectedTheme.toLowerCase()];
+		theme = json['data'];
 	}
 
 	document.getElementsByTagName('title')[0].textContent = `Theme Customiser - ${theme['name']}`;

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1304,7 +1304,8 @@ var theme = '',
 var userOpts = {
 	'data': themeUrls[0],
 	'options': {},
-	'mods': {}
+	'mods': {},
+	'json_version': jsonVersion
 };
 
 if(themeUrls.length === 0) {

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1304,8 +1304,7 @@ var theme = '',
 var userOpts = {
 	'data': themeUrls[0],
 	'options': {},
-	'mods': {},
-	'json_version': jsonVersion
+	'mods': {}
 };
 
 if(themeUrls.length === 0) {

--- a/assets/theme.json
+++ b/assets/theme.json
@@ -1,5 +1,6 @@
 {
-	"example": {
+	"json_version": 0.2,
+	"data": {
 		"name": "Example",
 		"author": "Your Name Here",
 		"css": "Your code here. I recommend placing a URL here as opposed to raw code, as placing code into JSON requires a lot of escape characters and pain.\n\n.textarea::before { content: \"\"; }",


### PR DESCRIPTION
Update JSON to new format.

Summarised changes in JSON:
- The old JSON format with multiple themes combined into one file is dead.
- Collections for the browse page are now their own JSON. This file has a "themes" array with all theme dictionaries.
- Themes now each have their own JSON. This JSON is almost the same as before, but has a "data" key instead of a custom theme ID key and any further themes will be ignored.
- URL format has changed. Collecton data is linked with any number of `c` parameters. Theme data is linked with a single `t` parmeter.
- All JSON files now begin with a "json_version" key that accepts a float value. This allows moving forwards with formatting changes while still processing older JSON as the author intended until they update.

Some other changes in this PR are:
- Improved back button display criteria. Now displays whenever there is a collection present.
- Settings import now always allows applying mismatched data on the current page even when theme name mismatches. This gives the user more control.

This PR will close #15.

Example new URL format:
```
https://valeriolyndon.github.io/Theme-Customiser/theme?t=https://example.com/theme.json&c=https://example.com/collection.json&c=https://example.com/collection2.json
```

Example collection.json:
```
{
    "json_version": 0.2,
    "themes": [
        {
            Accepted keys: 'name', 'author', 'image', 'type', 'url'.
            Most keys are mirrored from the theme data.
            The URL is a new key that links to the theme.json.
        }
    ]
}
```

Example theme.json:
```
{
    "json_version": 0.2,
    "data": {
        Same as previous theme dictionary but 'preview' key is no longer used and should be removed.
    }
}
```