### PR TITLE
Better filters

### DIFF
--- a/assets/browse.css
+++ b/assets/browse.css
@@ -100,6 +100,7 @@
 .filter__row {
 	display: flex;
 	margin-bottom: 4px;
+	align-items: flex-start;
 }
 .filter__row--center {
 	justify-content: center;
@@ -151,7 +152,8 @@
 	margin: 14px;
 	text-decoration: none;
 }
-.browser__card.is-hidden-by-tag {
+.browser__card.is-hidden-by-tag,
+.browser__card.is-hidden-by-search {
 	display: none;
 }
 

--- a/assets/browse.js
+++ b/assets/browse.js
@@ -106,25 +106,13 @@ function sortItems(items, attribute, order = 'ascending') {
 }
 
 function pushTag(thisId, tag, category = 'other') {
-	if(!tags[category][tag]) {
+	if( !tags[category] ){
+		tags[category] = [];
+	}
+	if( !tags[category][tag] ){
 		tags[category][tag] = [];
 	}
 	tags[category][tag].push(thisId);
-}
-
-// sorts a dictionary by key
-function sortKeys(dict) {
-	let keys = Object.keys(dict);
-	keys.sort((a,b) => {
-		return a.toLowerCase().localeCompare(b.toLowerCase());
-	});
-
-	let sorted = {};
-	for(let k of keys) {
-		sorted[k] = dict[k];
-	}
-
-	return sorted;
 }
 
 
@@ -244,12 +232,15 @@ function renderCards(cardData) {
 		// Add tags to sortable list
 		pushTag(thisId, theme['type'], 'list type');
 		pushTag(thisId, themeAuthor, 'author');
-		for(let tag of theme['tags'] ? theme['tags'] : []) {
-			let category = 'other';
-			if(['card layout', 'cover layout', 'table layout'].includes(tag)) {
-				category = 'layout';
+		if( theme['tags'] ){
+			if( theme['tags'] instanceof Array ){
+				theme['tags'] = {'other': theme['tags']};
 			}
-			pushTag(thisId, tag, category);
+			for( let [category, tags] of Object.entries(theme['tags']) ){
+				for( let tag of tags ){
+					pushTag(thisId, tag, category);
+				}
+			}
 		}
 		itemCount++;
 	}
@@ -263,9 +254,6 @@ function renderCards(cardData) {
 
 var tags = {
 		"list type": {},
-		"layout": {},
-		"author": {},
-		"source": {},
 		"other": {}
 	},
 	itemCount = 0,
@@ -352,25 +340,16 @@ fetchAllFiles(megaUrls)
 
 			loader.text('Filtering items...');
 
-			var filter = new filters(document.getElementsByClassName('js-card'), 'card:ID');
-
-			function renderBrowseTags(categoryName, categoryTags) {
-				let cloudEle = document.getElementById('js-tags__cloud');
-
-				let header = document.createElement('div');
-				header.textContent = capitalise(categoryName);
-				header.className = 'tag-cloud__header';
-				cloudEle.appendChild(header);
-
-				filter.renderHtml(categoryTags);
-			}
-
 			if(itemCount > 5) {
-				for(let [categoryName, categoryTags] of Object.entries(tags)) {
+				let hasTags = false;
+				for(let categoryTags of Object.values(tags)) {
 					if(Object.keys(categoryTags).length > 0) {
-						categoryTags = sortKeys(categoryTags);
-						renderBrowseTags(categoryName, categoryTags);
+						hasTags = true;
+						break;
 					}
+				}
+				if( hasTags ){
+					var filter = new filters(document.getElementsByClassName('js-card'), tags, 'card:ID');
 				}
 			}
 

--- a/assets/browse.js
+++ b/assets/browse.js
@@ -173,9 +173,6 @@ function renderCards(cardData) {
 			cardParent.setAttribute('data-author', theme['author']);
 		}
 
-		let themeTags = theme['tags'] ? theme['tags'] : [];
-		cardParent.setAttribute('data-tags', themeTags);
-
 		let card = document.createElement('div');
 		card.className = 'card';
 		cardParent.appendChild(card);
@@ -247,7 +244,7 @@ function renderCards(cardData) {
 		// Add tags to sortable list
 		pushTag(thisId, theme['type'], 'list type');
 		pushTag(thisId, themeAuthor, 'author');
-		for(let tag of themeTags) {
+		for(let tag of theme['tags'] ? theme['tags'] : []) {
 			let category = 'other';
 			if(['card layout', 'cover layout', 'table layout'].includes(tag)) {
 				category = 'layout';

--- a/assets/browse.js
+++ b/assets/browse.js
@@ -322,6 +322,12 @@ fetchAllFiles(megaUrls)
 				}
 			}
 
+			// Add search functionality
+
+			let search = document.getElementById('js-search');
+			filter.searchBar = search;
+			search.addEventListener('input', () => { filter.search(search.value, ['data-title']); } );
+
 			// Add sort dropdown items and apply default sort
 			var cards = document.getElementsByClassName('js-card');
 			

--- a/assets/browse.js
+++ b/assets/browse.js
@@ -2,20 +2,6 @@
 // COMMON FUNCTIONS
 // ================
 
-// Capitalises the first letter of every word. To capitalise sentences, set the divider to ".".
-function capitalise(str, divider = ' ') {
-	let words = str.split(divider);
-	
-	for(i = 0; i < words.length; i++) {
-		let first = words[i].substring(0,1).toUpperCase(),
-			theRest = words[i].substring(1);
-		words[i] = first + theRest;
-	}
-	
-	str = words.join(divider);
-	return str;
-}
-
 // Sort function
 
 /* Activated by user on click of a button. Updates relevant UI elements then call sortItems. 
@@ -103,16 +89,6 @@ function sortItems(items, attribute, order = 'ascending') {
 		let id = attributes[i][1];
 		document.getElementById(`card:${id}`).style.order = i;
 	}
-}
-
-function pushTag(thisId, tag, category = 'other') {
-	if( !tags[category] ){
-		tags[category] = [];
-	}
-	if( !tags[category][tag] ){
-		tags[category][tag] = [];
-	}
-	tags[category][tag].push(thisId);
 }
 
 
@@ -230,16 +206,13 @@ function renderCards(cardData) {
 		document.getElementById('js-theme-list').appendChild(cardParent);
 
 		// Add tags to sortable list
-		pushTag(thisId, theme['type'], 'list type');
-		pushTag(thisId, themeAuthor, 'author');
-		if( theme['tags'] ){
-			if( theme['tags'] instanceof Array ){
-				theme['tags'] = {'other': theme['tags']};
-			}
-			for( let [category, tags] of Object.entries(theme['tags']) ){
-				for( let tag of tags ){
-					pushTag(thisId, tag, category);
-				}
+		tempTags = formatFilters(theme['tags']);
+		tempTags['list type'] = [theme['type']];
+		tempTags['author'] = [themeAuthor];
+
+		for( let [category, tags] of Object.entries(tempTags) ){
+			for( let tag of tags ){
+				pushFilter(thisId, tag, category);
 			}
 		}
 		itemCount++;
@@ -252,11 +225,7 @@ function renderCards(cardData) {
 
 // Variables
 
-var tags = {
-		"list type": {},
-		"other": {}
-	},
-	itemCount = 0,
+var itemCount = 0,
 	sorts = ['data-title'];
 
 // Get data for all collections and call other functions

--- a/assets/browse.js
+++ b/assets/browse.js
@@ -353,10 +353,11 @@ fetchAllFiles(megaUrls)
 				renderCards(json['themes']);
 			}
 
-			loader.text('Sorting items...');
+			loader.text('Filtering items...');
+
+			var filter = new filters(document.getElementsByClassName('js-card'), 'card:ID');
 
 			function renderBrowseTags(categoryName, categoryTags) {
-
 				let cloudEle = document.getElementById('js-tags__cloud');
 
 				let header = document.createElement('div');
@@ -364,7 +365,7 @@ fetchAllFiles(megaUrls)
 				header.className = 'tag-cloud__header';
 				cloudEle.appendChild(header);
 
-				renderTags(categoryTags, [...Array(itemCount).keys()], 'card:ID');
+				filter.renderHtml(categoryTags);
 			}
 
 			if(itemCount > 5) {

--- a/assets/common.css
+++ b/assets/common.css
@@ -221,7 +221,9 @@ body {
 
 .tag-cloud {
 	display: flex;
+	width: 100%;
 	flex-flow: row wrap;
+	align-items: flex-start;
 	margin-bottom: 4px;
 }
 .tag-cloud--center {
@@ -230,6 +232,23 @@ body {
 }
 .tag-cloud.is-hidden {
 	display: none;
+}
+
+.tag-cloud__group {
+	display: flex;
+	width: fit-content;
+	flex-flow: row wrap;
+	max-width: 400px;
+	padding: 5px;
+	flex: 0 1 auto;
+}
+.tag-cloud__group:only-of-type {
+	max-width: initial;
+	padding: 0;
+	flex: 1 1 auto;
+}
+.tag-cloud__group--column {
+	flex-flow: column wrap;
 }
 
 .tag-cloud__blurb {
@@ -247,6 +266,8 @@ body {
 	flex: 0 0 auto;
 	margin-top: 8px;
 	margin-bottom: 4px;
+	text-align: left;
+	text-indent: 5px;
 }
 
 .tag-cloud__tag {

--- a/assets/common.css
+++ b/assets/common.css
@@ -135,6 +135,11 @@ body {
 	width: 60px;
 	text-align: center;
 }
+.input--search {
+	width: 200px;
+	padding: 3px 6px;
+	margin: 0 6px 6px 0;
+}
 
 .range {
 	width: calc(100% - 12px);

--- a/assets/common.css
+++ b/assets/common.css
@@ -269,6 +269,10 @@ body {
 	background: var(--accent);
 	color: var(--accent-text);
 }
+.tag-cloud__tag.is-disabled {
+	opacity: 0.5;
+	pointer-events: none;
+}
 
 .tag-cloud__count {
 	display: inline-block;

--- a/assets/common.js
+++ b/assets/common.js
@@ -260,6 +260,20 @@ function toggleEle(selector, btn = false, set = undefined) {
 	}
 }
 
+// Capitalises the first letter of every word. To capitalise sentences, set the divider to ".".
+function capitalise(str, divider = ' ') {
+	let words = str.split(divider);
+	
+	for(i = 0; i < words.length; i++) {
+		let first = words[i].substring(0,1).toUpperCase(),
+			theRest = words[i].substring(1);
+		words[i] = first + theRest;
+	}
+	
+	str = words.join(divider);
+	return str;
+}
+
 // sorts a dictionary by key
 function sortKeys(dict) {
 	let keys = Object.keys(dict);
@@ -276,6 +290,30 @@ function sortKeys(dict) {
 }
 
 // Tag Functionality & Renderer
+
+// Tag variables
+
+var tags = {};
+
+function formatFilters( filters ){
+	if( filters instanceof Array ){
+		return {'other': filters};
+	}
+	if( filters instanceof Object ){
+		return filters;
+	}
+	return {};
+}
+
+function pushFilter(thisId, tag, category = 'other') {
+	if( !tags[category] ){
+		tags[category] = [];
+	}
+	if( !tags[category][tag] ){
+		tags[category][tag] = [];
+	}
+	tags[category][tag].push(thisId);
+}
 
 /* Adds functional tags to the HTML.
  | 
@@ -318,6 +356,7 @@ class filters {
 		this.toggle.classList.remove('o-hidden');
 
 		let filterCategories = Object.entries(filters);
+		console.log(filters);
 		for( let [category, tags] of filterCategories ){
 			if( filterCategories.length > 1 ){
 				let header = document.createElement('div');

--- a/assets/common.js
+++ b/assets/common.js
@@ -260,6 +260,21 @@ function toggleEle(selector, btn = false, set = undefined) {
 	}
 }
 
+// sorts a dictionary by key
+function sortKeys(dict) {
+	let keys = Object.keys(dict);
+	keys.sort((a,b) => {
+		return a.toLowerCase().localeCompare(b.toLowerCase());
+	});
+
+	let sorted = {};
+	for(let k of keys) {
+		sorted[k] = dict[k];
+	}
+
+	return sorted;
+}
+
 // Tag Functionality & Renderer
 
 /* Adds functional tags to the HTML.
@@ -279,7 +294,7 @@ function toggleEle(selector, btn = false, set = undefined) {
  | • A div with ID 'js-tags__cloud'
  */
 class filters {
-	constructor( items, selector = 'ID' ){
+	constructor( items, filters, selector = 'ID' ){
 		// DOM Nodes
 		this.toggle = document.getElementById('js-tags__button');
 		this.container = document.getElementById('js-tags__cloud');
@@ -295,40 +310,55 @@ class filters {
 		this.btnCls = 'is-selected';
 		this.toggleCls = 'has-selected';
 
-		// Other
+		// Other Variables
 		this.selector = selector;
-	}
 
-	renderHtml( filters ) {
+
+		// Render HTML
 		this.toggle.classList.remove('o-hidden');
-		for(let [tag, itemIds] of Object.entries(filters)) {
-			let button = document.createElement('button'),
-				countEle = document.createElement('span'),
-				count = itemIds.length;
 
-			button.textContent = tag;
-			button.className = 'tag-cloud__tag';
-
-			// count of items
-			countEle.textContent = count;
-			countEle.className = 'tag-cloud__count';
-			button.appendChild(countEle);
-			this.container.appendChild(button);
-
-			// format Ids
-			for( let i = 0; i < itemIds.length; i++ ) {
-				itemIds[i] = this.formatId(itemIds[i]);
+		let filterCategories = Object.entries(filters);
+		for( let [category, tags] of filterCategories ){
+			if( filterCategories.length > 1 ){
+				let header = document.createElement('div');
+				header.textContent = capitalise(category);
+				header.className = 'tag-cloud__header';
+				this.container.appendChild(header);
 			}
 
-			this.buttons.push({
-				'btn': button,
-				'count': countEle,
-				'ids': itemIds,
-				'total': count
-			});
+			// Sort filters ascending
+			tags = sortKeys(tags);
 
-			// Add tag button functions
-			button.addEventListener('click', () => { this.activateFilter(button, tag, itemIds); });
+			// Create HTML
+			for(let [tag, itemIds] of Object.entries(tags)) {
+				let button = document.createElement('button'),
+					countEle = document.createElement('span'),
+					count = itemIds.length;
+
+				button.textContent = tag;
+				button.className = 'tag-cloud__tag';
+
+				// count of items
+				countEle.textContent = count;
+				countEle.className = 'tag-cloud__count';
+				button.appendChild(countEle);
+				this.container.appendChild(button);
+
+				// format Ids
+				for( let i = 0; i < itemIds.length; i++ ) {
+					itemIds[i] = this.formatId(itemIds[i]);
+				}
+
+				this.buttons.push({
+					'btn': button,
+					'count': countEle,
+					'ids': itemIds,
+					'total': count
+				});
+
+				// Add tag button functions
+				button.addEventListener('click', () => { this.activateFilter(button, tag, itemIds); });
+			}
 		}
 	}
 

--- a/assets/common.js
+++ b/assets/common.js
@@ -366,11 +366,26 @@ class BaseFilters {
 		for( let [category, tags] of tagCategories ){
 			let totalInCategory = 0;
 
+			let group = document.createElement('div');
+			group.className = 'tag-cloud__group';
+			if(category === 'other') {
+				group.style.order = 100;
+			} else if(category === 'list type') {
+				group.style.order = 1;
+				group.classList.add('tag-cloud__group--column');
+			} else if(category === 'layout') {
+				group.style.order = 2;
+				group.classList.add('tag-cloud__group--column');
+			} else {
+				group.style.order = 50;
+			}
+			this.tagContainer.appendChild(group);
+
 			let header = document.createElement('div');
 			if( tagCategories.length > 1 ){
 				header.textContent = capitalise(category);
 				header.className = 'tag-cloud__header';
-				this.tagContainer.appendChild(header);
+				group.appendChild(header);
 			}
 
 			// Sort filters ascending
@@ -397,7 +412,7 @@ class BaseFilters {
 				countEle.textContent = count;
 				countEle.className = 'tag-cloud__count';
 				button.appendChild(countEle);
-				this.tagContainer.appendChild(button);
+				group.appendChild(button);
 
 				// format Ids
 				for( let i = 0; i < itemIds.length; i++ ) {
@@ -417,7 +432,7 @@ class BaseFilters {
 
 			// If category is empty, skip
 			if( totalInCategory === 0 ){
-				header.remove();
+				group.remove();
 			}
 		}
 	}

--- a/assets/common.js
+++ b/assets/common.js
@@ -335,6 +335,7 @@ class filters {
 	constructor( items, filters, selector = 'ID' ){
 		// DOM Nodes
 		this.toggle = document.getElementById('js-tags__button');
+		this.clearBtn = document.getElementById('js-tags__clear');
 		this.container = document.getElementById('js-tags__cloud');
 		this.allItems = [...items];
 		this.hiddenItems = []; // Array
@@ -350,7 +351,13 @@ class filters {
 
 		// Other Variables
 		this.selector = selector;
+		this.clearBtn.classList.remove('o-hidden');
 
+
+		// Create Meta Buttons
+		this.clearBtn.addEventListener('click', () => {
+			this.showAll();
+		});
 
 		// Render HTML
 		this.toggle.classList.remove('o-hidden');
@@ -358,8 +365,10 @@ class filters {
 		let filterCategories = Object.entries(filters);
 		console.log(filters);
 		for( let [category, tags] of filterCategories ){
+			let totalInCategory = 0;
+
+			let header = document.createElement('div');
 			if( filterCategories.length > 1 ){
-				let header = document.createElement('div');
 				header.textContent = capitalise(category);
 				header.className = 'tag-cloud__header';
 				this.container.appendChild(header);
@@ -368,11 +377,18 @@ class filters {
 			// Sort filters ascending
 			tags = sortKeys(tags);
 
-			// Create HTML
+			// Create Filter Buttons
 			for(let [tag, itemIds] of Object.entries(tags)) {
 				let button = document.createElement('button'),
 					countEle = document.createElement('span'),
 					count = itemIds.length;
+
+				// skip rendering tag if all items match, thus making it useless
+				if( count === this.allItems.length ){
+					continue;
+				} else {
+					totalInCategory++;
+				}
 
 				button.textContent = tag;
 				button.className = 'tag-cloud__tag';
@@ -397,6 +413,11 @@ class filters {
 
 				// Add tag button functions
 				button.addEventListener('click', () => { this.activateFilter(button, tag, itemIds); });
+			}
+
+			// If category is empty, skip
+			if( totalInCategory === 0 ){
+				header.remove();
 			}
 		}
 	}
@@ -425,13 +446,18 @@ class filters {
 
 	// Show all items
 	showAll( ){
+		// Reset HTML
 		for( let item of this.hiddenItems ){
 			item.classList.remove(this.itemCls);
 		}
 		for( let btn of this.buttons ){
-			btn['btn'].classList.remove('is-disabled');
+			this.toggle.classList.remove(this.toggleCls);
+			btn['btn'].classList.remove('is-disabled', 'is-selected');
 			btn['count'].textContent = btn['total'];
 		}
+		// Reset variables
+		this.selectedButtons = [];
+		this.selectedFilters = [];
 		this.hiddenItems = [];
 		this.visibleItems = [...this.allItems];
 	}
@@ -459,7 +485,6 @@ class filters {
 
 		// If nothing is selected anymore, clear all.
 		if( this.selectedButtons.length === 0 ){
-			this.toggle.classList.remove(this.toggleCls);
 			this.showAll();
 			return;
 		}

--- a/assets/common.js
+++ b/assets/common.js
@@ -481,7 +481,7 @@ const
 	themeUrls = query.getAll('t'),
 	loader = new loadingScreen(),
 	messenger = new messageHandler(),
-	jsonVersion = 0.2;
+	jsonVersion = 0.3;
 
 
 
@@ -504,7 +504,8 @@ async function processJson(json, url, toReturn) {
 
 	// Else, continue to process.
 	if(ver > jsonVersion) {
-		console.log('Detected JSON version ahead of current release. Processing as normal.');
+		messenger.send('Detected JSON version beyond what is supported by this instance. Attempting to process as normal. If any bugs or failures occur, try using the main instance at valeriolyndon.github.io.');
+		console.log('Detected JSON version beyond what is supported by this instance. Attempting to process as normal. If any bugs or failures occur, try updating your fork from the main instance at valeriolyndon.github.io.');
 	}
 
 	else if(ver < jsonVersion) {

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1100,11 +1100,11 @@ function renderCustomisation(entryType, entry, parentEntry = [undefined, undefin
 
 		// Add mod tag to list of tags
 		if('tags' in entryData) {
-			for(let tag of entryData['tags']) {
-				if(modTags[tag]) {
-					modTags[tag].push(entryId);
-				} else {
-					modTags[tag] = [entryId];
+			tempTags = formatFilters(entryData['tags']);
+
+			for( let [category, tags] of Object.entries(tempTags) ){
+				for( let tag of tags ){
+					pushFilter(entryId, tag, category);
 				}
 			}
 		}
@@ -1200,9 +1200,8 @@ function pageSetup() {
 	}
 
 	// Tag links
-	if(Object.entries(modTags).length > 0 && Object.entries(theme['mods']).length > 3) {
-		var filter = new filters(mods, 'mod-parent:ID');
-		filter.renderHtml(modTags);
+	if(Object.entries(tags).length > 0 && Object.entries(theme['mods']).length > 3) {
+		var filter = new filters(mods, tags, 'mod-parent:ID');
 	}
 
 	// Back link
@@ -1825,7 +1824,7 @@ function postToIframe(msg) {
 var theme = '',
 	json = null,
 	baseCss = '',
-	modTags = {};
+	tags = {};
 
 var userSettings = {
 	'data': themeUrls[0],

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1201,7 +1201,8 @@ function pageSetup() {
 
 	// Tag links
 	if(Object.entries(tags).length > 0 && Object.entries(theme['mods']).length > 3) {
-		var filter = new filters(mods, tags, 'mod-parent:ID');
+		var filter = new filters(mods, 'mod-parent:ID');
+		filter.renderTags(tags);
 	}
 
 	// Back link

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1183,6 +1183,7 @@ function pageSetup() {
 		optionsEle.parentNode.remove();
 	}
 
+	let mods = [];
 	let modsEle = document.getElementById('js-mods');
 	if('mods' in theme) {
 		for (const mod of Object.entries(theme['mods'])) {
@@ -1190,6 +1191,7 @@ function pageSetup() {
 			if(typeof renderedMod === 'string') {
 				console.log(`[ERROR] Skipped mod "${modId}": ${renderedMod}`);
 			} else {
+				mods.push(renderedMod);
 				modsEle.appendChild(renderedMod);
 			}
 		}
@@ -1199,7 +1201,8 @@ function pageSetup() {
 
 	// Tag links
 	if(Object.entries(modTags).length > 0 && Object.entries(theme['mods']).length > 3) {
-		renderTags(modTags, Object.keys(theme['mods']), 'mod-parent:ID');
+		var filter = new filters(mods, 'mod-parent:ID');
+		filter.renderHtml(modTags);
 	}
 
 	// Back link

--- a/assets/customiser.js
+++ b/assets/customiser.js
@@ -1201,7 +1201,7 @@ function pageSetup() {
 
 	// Tag links
 	if(Object.entries(tags).length > 0 && Object.entries(theme['mods']).length > 3) {
-		var filter = new filters(mods, 'mod-parent:ID');
+		var filter = new BaseFilters(mods, 'mod-parent:ID');
 		filter.renderTags(tags);
 	}
 

--- a/index.html
+++ b/index.html
@@ -72,6 +72,10 @@
 					<button class="button o-hidden" id="js-tags__button" onclick="toggleEle('#js-tags__cloud', this)">
 						<i class="fa-solid fa-tags"></i> Filters
 					</button>
+
+					<button class="button o-hidden" id="js-tags__clear">
+							<i class="fa-solid fa-xmark"></i> Clear
+						</button>
 				</div>
 
 				<div class="filter__row">

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 						</div>
 					</div>
 
-					<input class="input input--search" type="search" placeholder="Search titles..." id="js-search" />
+					<input class="input input--search o-hidden" type="search" placeholder="Search titles..." id="js-search" />
 
 					<button class="button o-hidden" id="js-tags__button" onclick="toggleEle('#js-tags__cloud', this)">
 						<i class="fa-solid fa-tags"></i> Filters

--- a/index.html
+++ b/index.html
@@ -69,12 +69,14 @@
 						</div>
 					</div>
 
+					<input class="input input--search" type="search" placeholder="Search titles..." id="js-search" />
+
 					<button class="button o-hidden" id="js-tags__button" onclick="toggleEle('#js-tags__cloud', this)">
 						<i class="fa-solid fa-tags"></i> Filters
 					</button>
 
-					<button class="button o-hidden" id="js-tags__clear">
-							<i class="fa-solid fa-xmark"></i> Clear
+					<button class="button o-hidden" id="js-tags__clear" onclick="document.getElementById('js-search').value = '';">
+							<i class="fa-solid fa-xmark"></i> Clear All
 						</button>
 				</div>
 

--- a/index.html
+++ b/index.html
@@ -39,34 +39,7 @@
 						<button class="button button--unusable">
 							<i class="fa-solid fa-sort"></i> Sort
 						</button>
-						<div class="dropdown__box">
-							<div class="dropdown__item">
-								<a class="hyper-button js-sort" id="js-sort-title">
-									Title
-									<i class="hyper-button__icon fa-solid fa-sort-asc o-hidden js-ascending js-sort-icon"></i>
-									<i class="hyper-button__icon fa-solid fa-sort-desc o-hidden js-descending js-sort-icon"></i>
-								</a>
-							</div>
-							<div class="dropdown__item">
-								<a class="hyper-button js-sort" id="js-sort-author">
-									Author
-									<i class="hyper-button__icon fa-solid fa-sort-asc o-hidden js-ascending js-sort-icon"></i>
-									<i class="hyper-button__icon fa-solid fa-sort-desc o-hidden js-descending js-sort-icon"></i>
-								</a>
-							</div>
-							<div class="dropdown__item">
-								<a class="hyper-button js-sort" id="js-sort-date">
-									Release Date
-									<i class="hyper-button__icon fa-solid fa-sort-asc o-hidden js-ascending js-sort-icon"></i>
-									<i class="hyper-button__icon fa-solid fa-sort-desc o-hidden js-descending js-sort-icon"></i>
-								</a>
-							</div>
-							<div class="dropdown__item">
-								<a class="hyper-button js-sort" id="js-sort-random">
-									Random
-								</a>
-							</div>
-						</div>
+						<div id="js-sorts" class="dropdown__box"></div>
 					</div>
 
 					<input class="input input--search o-hidden" type="search" placeholder="Search titles..." id="js-search" />

--- a/theme.html
+++ b/theme.html
@@ -107,13 +107,13 @@ permalink: /theme
 								Choose theme modifications
 								<div class="sidebar__header-aside">
 									<button type="button" class="button o-hidden" id="js-tags__button" onclick="toggleEle('#js-tags__cloud', this)">
-										<i class="fa-solid fa-tags"></i> Tags
+										<i class="fa-solid fa-tags"></i> Filters
 									</button>
 								</div>
 							</h3>
 
 							<div class="tag-cloud is-hidden" id="js-tags__cloud">
-								<small class="tag-cloud__blurb">Select a tag that interests you to narrow results.</small>
+								<small class="tag-cloud__blurb">Select a subject that interests you to narrow results.</small>
 							</div>
 							
 							<!-- mods gets put here by customiser.js -->


### PR DESCRIPTION
In this PR:
- JSON version bumped to 0.3.
- "tags" keys can now be dictionaries instead of arrays, allowing for categories. Example:
```
"tags": {
  "myCategory": ["myTag", "mySecondTag"],
  "mySecondCategory": …
  …
}
```
- Multiple tags can now be selected using "AND" logic. 
- Added search for titles on browse page.
- Sort, tags, and search are all saved in the URL for easy linking and so that the page will remember on refresh.
- Improved style of tag clouds.

Will resolve #36 